### PR TITLE
add support for go module and utf8 string in v.Len

### DIFF
--- a/builtin.go
+++ b/builtin.go
@@ -2,6 +2,7 @@ package validating
 
 import (
 	"time"
+	"unicode/utf8"
 )
 
 // FromFunc is an adapter to allow the use of ordinary functions as
@@ -313,7 +314,7 @@ func Len(min, max int, msgs ...string) Validator {
 			l := len(*t)
 			valid = l >= min && l <= max
 		case *string:
-			l := len(*t)
+			l := utf8.RuneCountInString(*t)
 			valid = l >= min && l <= max
 		case *[]string:
 			l := len(*t)

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,1 @@
+module github.com/RussellLuo/validating

--- a/validating_test.go
+++ b/validating_test.go
@@ -104,6 +104,15 @@ func TestAll(t *testing.T) {
 			},
 			nil,
 		},
+		{
+			func() v.Schema {
+				value := "hello,中国"
+				return v.Schema{
+					v.F("value", &value): v.All(v.Nonzero(), v.Len(1, 8)),
+				}
+			},
+			nil,
+		},
 	}
 	for _, c := range cases {
 		errs := v.Validate(c.schemaMaker())


### PR DESCRIPTION
hi, I found v.Len use 'len'  to get string length, it will be wrong for multi byte string. so i change it into 'utf8.RuneCountInString'
